### PR TITLE
Add global issues section

### DIFF
--- a/generateTestPlan.groovy
+++ b/generateTestPlan.groovy
@@ -107,7 +107,7 @@ void renderTestPlan(List<Sample> samples) {
         ### 3.1 Global issues
         
         The following problems persists across all scenarios (most often IDE or Gradle-plugin related issues).
-        If any of the following scenarios are fixed, delete the line in [`generateTestPlan.groovy`](/generateTestPlan.groovy)
+        If any of the following scenarios are fixed, delete the line in `generateTestPlan.groovy`
         
         - [ ] [IDEA-353787](https://youtrack.jetbrains.com/issue/IDEA-353787/GradleResourceFilterModelBuilder-causes-Gradle-deprecation-warnings-when-projects-are-imported) - When projects are imported, they report a `CopyProcessingSpec` deprecation warning. 
     """.stripIndent(8).strip()

--- a/generateTestPlan.groovy
+++ b/generateTestPlan.groovy
@@ -103,6 +103,13 @@ void renderTestPlan(List<Sample> samples) {
         - Link the issue in the sample project:
           -  Add the following comment to the failing line `// Known issue: https://youtrack.jetbrains.com/issue/IDEA-123456`
         - add an X (red cross emoji) to the list below and link the created issue there as well
+
+        ### 3.1 Global issues
+        
+        The following problems persists across all scenarios (most often IDE or Gradle-plugin related issues).
+        If any of the following scenarios are fixed, delete the line in [`generateTestPlan.groovy`](/generateTestPlan.groovy)
+        
+        - [ ] [IDEA-353787](https://youtrack.jetbrains.com/issue/IDEA-353787/GradleResourceFilterModelBuilder-causes-Gradle-deprecation-warnings-when-projects-are-imported) - When projects are imported, they report a `CopyProcessingSpec` deprecation warning. 
     """.stripIndent(8).strip()
 
     samples.each { Sample sample ->


### PR DESCRIPTION
Some issues like deprecation warnings are not scenario dependant.
In this case, I think it's more more efficient if we have one section in the issue where we can document these vs. across all scenarios.